### PR TITLE
Add VS Code devcontainer and docker-compose for Node + embedding service

### DIFF
--- a/.devcontainer/Dockerfile.node
+++ b/.devcontainer/Dockerfile.node
@@ -1,0 +1,10 @@
+FROM node:23-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ffmpeg \
+    python3 \
+    python3-pip \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/my-central-hub

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "my-central-hub",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace/my-central-hub",
+  "forwardPorts": [8080, 8000],
+  "portsAttributes": {
+    "8080": {
+      "label": "Node API"
+    },
+    "8000": {
+      "label": "Embedding Service"
+    }
+  },
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-typescript-next",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.9"
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile.node
+    volumes:
+      - ..:/workspace/my-central-hub:cached
+      - node_modules:/workspace/my-central-hub/node_modules
+    working_dir: /workspace/my-central-hub
+    command: sleep infinity
+    ports:
+      - "8080:8080"
+    environment:
+      EMBEDDING_SERVICE_URL: http://embed:8080
+    depends_on:
+      - embed
+
+  embed:
+    build:
+      context: ../python/services/embedding-service
+      dockerfile: Dockerfile.embed
+    volumes:
+      - ../public/media:/media
+    command: sleep infinity
+    ports:
+      - "8000:8080"
+
+volumes:
+  node_modules:


### PR DESCRIPTION
### Motivation

- Provide a reproducible development environment for the Node application and a Python embedding service using VS Code DevContainers and Docker Compose.
- Ensure required tools (Node, Python, ffmpeg, git) and workspace setup are available consistently for contributors.

### Description

- Add `.devcontainer/Dockerfile.node` to base images on `node:23-slim` and install `git`, `ffmpeg`, `python3`, and `python3-pip`, and set `WORKDIR` to `/workspace/my-central-hub`.
- Add `.devcontainer/devcontainer.json` to configure the devcontainer, forward ports `8080` and `8000`, run `npm install` after creation, and recommend VS Code extensions for JS/TS and Python development.
- Add `.devcontainer/docker-compose.yml` to define `app` and `embed` services; `app` builds from the new Dockerfile and mounts the repo, and `embed` builds the embedding service from `../python/services/embedding-service` with port mapping to `8000`.
- Configure shared `node_modules` volume, environment variable `EMBEDDING_SERVICE_URL`, and keep containers idle (`sleep infinity`) for interactive development.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29db93ca4832e87ac0d414414ddaa)